### PR TITLE
feat: Add support for GitHub Actions in travis-haskell

### DIFF
--- a/bin/travis-haskell
+++ b/bin/travis-haskell
@@ -13,7 +13,8 @@ set -eu
 # See below for documentation of each subcommand.
 
 # Determine the Haskell package we're building.
-PACKAGE=$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|^[^/]*/hs-||')
+REPO_SLUG="${TRAVIS_REPO_SLUG:-$GITHUB_REPOSITORY}"
+PACKAGE=$(echo "$REPO_SLUG" | sed -e 's|^[^/]*/hs-||')
 
 # Usage: download [slug] [tool] [output-path] [host]
 #


### PR DESCRIPTION
The name `travis-haskell` is a bit unfortunate, but this makes it usable from GitHub Actions as well. I could also copy-paste the script and give it a name like `ci-haskell`. Renaming the script would break a lot of our CI due to usage like this: https://github.com/TokTok/c-toxcore/blob/master/.travis/cmake-linux#L11-L14.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/ci-tools/24)
<!-- Reviewable:end -->
