### PR TITLE
fix: Fail the hackage_upload script on upload failure.

### DIFF
--- a/bin/hackage_upload
+++ b/bin/hackage_upload
@@ -10,19 +10,20 @@ else
   CANDIDATES=""
 fi
 
+cabal sdist
+PACKAGE=$(grep '^name:' *.cabal | awk '{print $2}')
+VERSION=$(grep '^version:' *.cabal | awk '{print $2}')
+
 DIST_URL="https://hackage.haskell.org/packages$CANDIDATES"
 DOCS_URL="https://hackage.haskell.org/package/$PACKAGE-$VERSION$CANDIDATE/docs"
 
 echo "Source upload URL: $DIST_URL"
 echo "Docs upload URL:   $DOCS_URL"
 
-cabal sdist
-PACKAGE=$(grep '^name:' *.cabal | awk '{print $2}')
-VERSION=$(grep '^version:' *.cabal | awk '{print $2}')
-curl --header "Authorization: X-ApiKey $API_TOKEN_HACKAGE" \
+curl --fail --header "Authorization: X-ApiKey $API_TOKEN_HACKAGE" \
   -F "package=@dist-newstyle/sdist/$PACKAGE-$VERSION.tar.gz" \
   "$DIST_URL"
-curl --header "Authorization: X-ApiKey $API_TOKEN_HACKAGE" \
+curl --fail --header "Authorization: X-ApiKey $API_TOKEN_HACKAGE" \
   -X PUT \
   -H "Content-Type: application/x-tar" \
   -H "Content-Encoding: gzip" \


### PR DESCRIPTION
Without the `--fail` flag, curl will succeed on HTTP errors. We want to
fail the GH workflow if upload fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/ci-tools/30)
<!-- Reviewable:end -->
