### PR TITLE
fix: Disable release version check when there's no draft release.

### DIFF
--- a/bin/check_release
+++ b/bin/check_release
@@ -25,9 +25,10 @@ def release_github():
     )
     release = resp.json()[0]
     if not release["draft"]:
-        print("Could not find the latest draft release.")
+        print("WARNING: Could not find the latest draft release.")
+        print("WARNING: Skipping this check.")
         print(f"Latest release found was {release['name']}")
-        sys.exit(1)
+        sys.exit(0)
     return release["name"][1:]
 
 


### PR DESCRIPTION
This happens on the first PR after a release when release-drafter hasn't
produced a new draft release yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/ci-tools/34)
<!-- Reviewable:end -->
