### PR TITLE
chore: Allow stack build to recover caches from other ghc versions.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -65,6 +65,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-
             ${{ runner.os }}-${{ env.ghc-version }}-
+            ${{ runner.os }}-
 
       - name: Install non-Haskell dependencies
         run: if [ -f tools/prepare_third_party.sh ]; then tools/prepare_third_party.sh; fi


### PR DESCRIPTION
It doesn't actually care about the ghc version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/ci-tools/43)
<!-- Reviewable:end -->
