### PR TITLE
chore: Downgrade ghc to 8.10.7.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -4,11 +4,11 @@ on:
       ghc-version:
         required: false
         type: string
-        default: "9.2.1"
+        default: "8.10.7"
       cabal-version:
         required: false
         type: string
-        default: "3.6.2.0"
+        default: "3.4"
 
 jobs:
   cabal:


### PR DESCRIPTION
`generic-arbitrary` doesn't compile yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/ci-tools/44)
<!-- Reviewable:end -->
