### PR TITLE
chore: Use BUILD.bazel instead of cabal file for cache keys.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -31,7 +31,7 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}
+          key: ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-${{ hashFiles('BUILD.bazel') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-
             ${{ runner.os }}-${{ env.ghc-version }}-
@@ -61,7 +61,7 @@ jobs:
           path: |
             ~/.stack
             .stack-work
-          key: ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-${{ hashFiles('BUILD.bazel') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ghc-version }}-${{ env.cache-name }}-
             ${{ runner.os }}-${{ env.ghc-version }}-


### PR DESCRIPTION
The `.cabal` files are updated whenever a new source file is added. We
don't want to make a whole new cache everytime we do that. We invalidate
the cache only when dependencies change, which generally means the BUILD
file also changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/ci-tools/48)
<!-- Reviewable:end -->
