### PR TITLE
chore: Migrate from haskell/actions/setup to haskell-actions/setup.

### DIFF
--- a/.github/workflows/haskell-publish.yml
+++ b/.github/workflows/haskell-publish.yml
@@ -47,7 +47,7 @@ jobs:
           repository: TokTok/ci-tools
           path: ci-tools
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ inputs.ghc-version }}
           cabal-version: ${{ inputs.cabal-version }}


### PR DESCRIPTION
The former is deprecated.

See https://github.com/haskell/actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/72)
<!-- Reviewable:end -->
