### PR TITLE
fix: Check out the PR head instead of merge commit in restyled.

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: restyled-io/actions/setup@v4
       - id: restyler
         uses: restyled-io/actions/run@v4


### PR DESCRIPTION
Should fix "The checked out commit does not match the event PR's head. 20a741e0d90339ae3f2bca41326e73f8ca6389db !=
715caf13cf2906727bffe7c4b6e964455d1c6bc5. Weird things may happen."

E.g. https://github.com/TokTok/qTox/actions/runs/12591052375?pr=354

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/88)
<!-- Reviewable:end -->
