### PR TITLE
fix(Security): Don't pass tokens to repo-local code.

### DIFF
--- a/tools/update-versions.sh
+++ b/tools/update-versions.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# If GITHUB_TOKEN or TOKEN_RELEASES are visible, error.
+if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${TOKEN_RELEASES:-}" ]; then
+  echo "GITHUB_TOKEN/TOKEN_RELEASES should not be visible in the version update script."
+  exit 1
+fi
+
+# After the token check. We don't want to print tokens to the logs.
 set -eux -o pipefail
 
 VERSION=$1

--- a/tools/update_flathub_descriptor_dependencies.py
+++ b/tools/update_flathub_descriptor_dependencies.py
@@ -53,21 +53,18 @@ def parse_args() -> Config:
         help="Path to the dockerfiles/qtox/download directory",
         required=False,
         default=DOWNLOAD_FILE_PATHS,
-        dest="download_files_path",
     )
     parser.add_argument(
         "--git-tag",
         help="Git tag to use for the qTox version",
         required=False,
         default=None,
-        dest="git_tag",
     )
     parser.add_argument(
         "--quiet",
         help="Suppress output",
         action=argparse.BooleanOptionalAction,
         default=False,
-        dest="quiet",
     )
     return Config(**vars(parser.parse_args()))
 
@@ -181,6 +178,10 @@ def find_manifest() -> Optional[pathlib.Path]:
     return None
 
 
+def _normalize(name: str) -> str:
+    return name.lower().replace("-", "").replace("_", "")
+
+
 def main(config: Config) -> None:
     if not config.flathub_manifest_path:
         # Try to detect where the manifest is. See if there's a single
@@ -199,7 +200,8 @@ def main(config: Config) -> None:
     flathub_manifest = load_flathub_manifest(config.flathub_manifest_path)
 
     self_version = config.git_tag or git.current_tag()
-    self_name = GIT_ROOT.name.lower().replace("-", "")
+    self_name = _normalize(GIT_ROOT.name)
+    print("Using version", self_version, "for", self_name)
 
     download_files_dir = pathlib.Path(config.download_files_path)
     download_file_map = {
@@ -209,7 +211,7 @@ def main(config: Config) -> None:
 
     for module in flathub_manifest["modules"]:
         module_name = str(module["name"])
-        if module_name.lower().replace("-", "") == self_name:
+        if _normalize(module_name) == self_name:
             update_git_source(module, self_version)
         else:
             filename = download_file_map.get(module_name, module_name)


### PR DESCRIPTION
We can use tokens in ci-tools code, but not in the version update scripts in user repos.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/123)
<!-- Reviewable:end -->
