### PR TITLE
cleanup: Use ci-tools macos build script.

### DIFF
--- a/.github/workflows/deploy-macos.yml
+++ b/.github/workflows/deploy-macos.yml
@@ -138,7 +138,7 @@ jobs:
           --set-config=max_size=200M
           --set-config=cache_dir="$PWD/.cache/ccache" && ccache --show-config
       - name: Build application bundle
-        run: platform/macos/build.sh
+        run: third_party/ci-tools/platform/macos/build.sh
           --project-name ${{ steps.artifact.outputs.project-name }}
           --build-type dist
           --arch "${{ matrix.arch }}"


### PR DESCRIPTION
Instead of repo-local ones. These are the same in every repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/133)
<!-- Reviewable:end -->
