### PR TITLE
fix: Disable clazy check as it is missing cmake dependencies.

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -2,4 +2,13 @@
 restylers:
   - pyment:
       enabled: false
+  - clazy:
+      enabled: false
+  # Disable conflicting python linters.
+  # Conflicts with "isort"
+  - reorder-python-imports:
+      enabled: false
+  # Conflicts with "black"
+  - yapf:
+      enabled: false
   - "*"


### PR DESCRIPTION
### Clazy changes
In the restylers configuration , staring from [v0.597.0 (2025-09-19)](https://github.com/restyled-io/restylers/releases/tag/v0.597.0) the new linter [clazy](https://github.com/KDE/clazy) was introduced. It relies on the [pre built docker image](https://github.com/restyled-io/restylers/blob/a91a2087a5fc40e17330d7360640f61ac8959014/clazy/Dockerfile#L6), which is missing some dependencies, including `PkgConfig`.
In this PR I have disabled the linter for now, however, the longer term solution would be to use docker image, which supports building qTox.

Currently CI/CD will always fail with the error
```
CMake Error at /usr/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
Call Stack (most recent call first):
  /usr/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.31/Modules/FindPkgConfig.cmake:114 (find_package_handle_standard_args)
  cmake/Dependencies.cmake:12 (find_package)
  CMakeLists.txt:194 (include)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/161)
<!-- Reviewable:end -->

### Changes to `mypy`
There were some insignificant changes related to `minidom` typing, which used to break the CI/CD. I have added two type fixes to pass.

### Changes for python linters
The new version of restyled also introduces several python linters i.e. `autopep8`, `black`, etc. 
Most of changes in the `tools/translate.py` are caused by `black`.
I had to disable several python linters in restyled as without additional parameters they conflict with each other. For example `black` will reformat file, which will always be reformatted with `yapf`.