### PR TITLE
fix: Setup custom codeQL with the latest codeql-actions.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '51 0 * * 6'
+
+env:
+  CODEQL_EXTRACTOR_ACTIONS_WIP_DATABASE: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        - language: python
+          build-mode: none
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Recently we have started to see the failures of javascript/typescript check of CodeQL: [here](https://github.com/TokTok/ci-tools/actions/runs/21097684833) is one example.

The issue happens because the action `github/codeql-action/analyze@v3` does not set the variable to `CODEQL_EXTRACTOR_ACTIONS_WIP_DATABASE`, which is needed by the new version of CodeQL binary to analyse the GitHub actions. This results in [warning](https://github.com/github/codeql/blob/1c689d060bed5df14cfecf69f46cd213413c10db/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java#L498) and consequent failure to finalize the database: CodeQL detected code written in JavaScript/TypeScript but could not process any of it.

There are two possible soilutions:
- In the advanced scenario we can set the variable `CODEQL_EXTRACTOR_ACTIONS_WIP_DATABASE` (this PR).
- Or we can enable GitHub option in `default` CodeQL scenario (set through GitHub UI)  and disable javascript check as we do not have the java script code in this repository.
 
I have [checked](https://github.com/nickolay168/ci-tools/pull/1) the fix on the forked repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/162)
<!-- Reviewable:end -->
