### PR TITLE
fix: Add check that the translation event contains data.

### DIFF
--- a/tools/translate.py
+++ b/tools/translate.py
@@ -208,7 +208,9 @@ def _baidu_call_translate(lang: Language, text: str) -> str:
     translations = (
         para["dst"]
         for event in events
-        if event["data"]["event"] == "Translating" and event["data"]["list"]
+        if event["data"]
+        and event["data"]["event"] == "Translating"
+        and event["data"]["list"]
         for para in event["data"]["list"]
     )
     return "\n".join(translations)


### PR DESCRIPTION
Sometimes the translation event, returned from Baidu does not contain the `data` object. In this PR I am adding the corresponding check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/163)
<!-- Reviewable:end -->
