### PR TITLE
fix: Improve release progress tracking and publication links.

### DIFF
--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -149,7 +149,8 @@ class Releaser:
 
         # 1. Preparation
         if self.github.find_pr_for_branch(
-            f"{self.github.actor()}:{BRANCH_PREFIX}/{version}", self.config.main_branch
+            f"{self.git.owner('origin')}:{BRANCH_PREFIX}/{version}",
+            self.config.main_branch,
         ):
             done.add("Preparation")
 
@@ -888,12 +889,14 @@ class Releaser:
                 return
             if self.config.github_actions:
                 s.ok("Asking user to publish the release")
+                release = self.github.release(version)
+                url = release["html_url"]
                 raise self.assign_to_user(
                     s,
                     version,
                     task="Publication",
                     action="publish the release",
-                    instruction=f"All checks passed and assets signed. Please [publish the release](https://github.com/{self.github.repository()}/releases/tag/{version}) manually.",
+                    instruction=f"All checks passed and assets signed. Please [publish the release]({url}) manually.",
                 )
             s.ok("Not implemented yet")
 

--- a/tools/lib/github.py
+++ b/tools/lib/github.py
@@ -335,6 +335,20 @@ class GitHub:
             return rid
         raise ValueError(f"Release {tag} not found in {self.repository()}")
 
+    def get_release(self, tag: str) -> Any:
+        """Get the full release object for a tag, or None if not found."""
+        rid = self.get_release_id(tag)
+        if rid is None:
+            return None
+        return self.api_uncached(f"/repos/{self.repository()}/releases/{rid}")
+
+    def release(self, tag: str) -> Any:
+        """Get the full release object for a tag."""
+        release = self.get_release(tag)
+        if release is not None:
+            return release
+        raise ValueError(f"Release {tag} not found in {self.repository()}")
+
     def actor(self) -> str:
         """Returns the GitHub username for the current repository."""
         github_actor = os.getenv("GITHUB_ACTOR")


### PR DESCRIPTION
- Ensure the 'Preparation' checkbox is correctly checked in CI by using the repository owner instead of the actor for PR identification.
- Use the dynamic draft release URL from GitHub for the publication instruction link.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/174)
<!-- Reviewable:end -->
