### PR TITLE
feat: Use unified naming convention for iOS artifacts.

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -24,11 +24,11 @@ jobs:
     name: Build
     strategy:
       matrix:
-        arch: [arm64, x86_64, arm64-iphonesimulator]
+        arch: [ios-arm64, iphonesimulator-arm64, iphonesimulator-x86_64]
         ios: ["15.0"]
         exclude:
-          - arch: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'packaging') && 'x86_64' }}
-          - arch: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'packaging') && 'arm64-iphonesimulator' }}
+          - arch: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'packaging') && 'iphonesimulator-x86_64' }}
+          - arch: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'packaging') && 'iphonesimulator-arm64' }}
     runs-on: macos-14
     permissions:
       contents: write
@@ -67,13 +67,7 @@ jobs:
           echo "artifact=$ARTIFACT" >>$GITHUB_OUTPUT
           echo "artifact-ref=$PROJECT_NAME-${{ github.sha }}-ios-${{ matrix.ios }}-${{ matrix.arch }}" >>$GITHUB_OUTPUT
 
-          if [ "${{ matrix.arch }}" = "x86_64" ]; then
-            echo "qt_arch=iphonesimulator-x86_64" >>$GITHUB_OUTPUT
-          elif [ "${{ matrix.arch }}" = "arm64-iphonesimulator" ]; then
-            echo "qt_arch=iphonesimulator-arm64" >>$GITHUB_OUTPUT
-          else
-            echo "qt_arch=ios-arm64" >>$GITHUB_OUTPUT
-          fi
+          echo "qt_arch=${{ matrix.arch }}" >>$GITHUB_OUTPUT
       - name: Download Qt
         if: inputs.need-qt
         run: |

--- a/platform/ios/build.sh
+++ b/platform/ios/build.sh
@@ -69,12 +69,19 @@ if [ -z "${PROJECT_NAME+x}" ]; then
   exit 1
 fi
 
-if [[ "$IOS_ARCH" == *"iphonesimulator"* ]] || [[ "$IOS_ARCH" == "x86_64" ]]; then
+if [[ "$IOS_ARCH" == "iphonesimulator-"* ]]; then
   IOS_PLATFORM="iphonesimulator"
+  CMAKE_ARCH="${IOS_ARCH#iphonesimulator-}"
+elif [[ "$IOS_ARCH" == "ios-"* ]]; then
+  IOS_PLATFORM="iphoneos"
+  CMAKE_ARCH="${IOS_ARCH#ios-}"
+else
+  # Fallback for simple architecture strings
+  CMAKE_ARCH="$IOS_ARCH"
+  if [[ "$IOS_ARCH" == "x86_64" ]]; then
+    IOS_PLATFORM="iphonesimulator"
+  fi
 fi
-
-# Extract the base architecture (e.g., "arm64" from "arm64-iphonesimulator")
-CMAKE_ARCH="${IOS_ARCH%-iphonesimulator}"
 
 readonly BIN_NAME="$PROJECT_NAME-$IOS_ARCH-$IOS_VERSION.ipa"
 CMAKE="$DEP_PREFIX/qt/bin/qt-cmake"


### PR DESCRIPTION
iOS build matrix and Qt architecture mapping are now ios-arm64, iphonesimulator-arm64, iphonesimulator-x86_64.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/187)
<!-- Reviewable:end -->
