### PR TITLE
fix: Fix the libqrencode build under MacOS 10.15

### DIFF
--- a/platform/macos/build.sh
+++ b/platform/macos/build.sh
@@ -94,6 +94,7 @@ ccache --zero-stats
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_VERSION" \
   -DCMAKE_PREFIX_PATH="$PREFIX_PATH" \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
   -GNinja \
   -B_build \
   "$@" \

--- a/tools/circleci-bazel-test
+++ b/tools/circleci-bazel-test
@@ -52,7 +52,7 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 pushd /src/workspace
-curl -L https://github.com/buchgr/bazel-remote/releases/download/v2.5.0/bazel-remote-2.5.0-linux-x86_64 -o "$TMPDIR/bazel-remote"
+curl -L https://github.com/buchgr/bazel-remote/releases/download/v2.6.1/bazel-remote-2.6.1-linux-amd64 -o "$TMPDIR/bazel-remote"
 # TODO(iphydf): Use bazel once the image is updated.
 # bazel run @patchelf//:patchelf -- --set-interpreter /nix/store/*-glibc-*/lib64/ld-linux-x86-64.so.2 "$TMPDIR/bazel-remote"
 "$PATCHELF" --set-interpreter /nix/store/*-glibc-*/lib64/ld-linux-x86-64.so.2 "$TMPDIR/bazel-remote"


### PR DESCRIPTION
In MacOS 10.15 I have stareted seeing the CI failures as [follows](https://github.com/TokTok/qTox/actions/runs/23729467405/job/69120001495?pr=699):
```
cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/Users/runner/work/deps -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DWITH_TOOLS=OFF -DBUILD_SHARED_LIBS=OFF
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
``` 
It is caused by [this line](https://github.com/fukuchi/libqrencode/blob/715e29fd4cd71b6e452ae0f4e36d917b43122ce8/CMakeLists.txt#L1) in the libqrencode CmakeLists.txt. I have added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` flag to redefine the minimal Cmake version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/200)
<!-- Reviewable:end -->
