### PR TITLE
fix: Make circleci-bazel-test work with multiple glibc versions.

### DIFF
--- a/tools/circleci-bazel-test
+++ b/tools/circleci-bazel-test
@@ -55,7 +55,10 @@ pushd /src/workspace
 curl -L https://github.com/buchgr/bazel-remote/releases/download/v2.5.0/bazel-remote-2.5.0-linux-x86_64 -o "$TMPDIR/bazel-remote"
 # TODO(iphydf): Use bazel once the image is updated.
 # bazel run @patchelf//:patchelf -- --set-interpreter /nix/store/*-glibc-*/lib64/ld-linux-x86-64.so.2 "$TMPDIR/bazel-remote"
-"$PATCHELF" --set-interpreter /nix/store/*-glibc-*/lib64/ld-linux-x86-64.so.2 "$TMPDIR/bazel-remote"
+# The image may contain multiple glibc versions, making a /nix/store/*-glibc-*
+# glob ambiguous; take the interpreter from an existing dynamically-linked binary.
+INTERP=$("$PATCHELF" --print-interpreter "$(command -v env)")
+"$PATCHELF" --set-interpreter "$INTERP" "$TMPDIR/bazel-remote"
 chmod +x "$TMPDIR/bazel-remote"
 popd
 


### PR DESCRIPTION
The `--set-interpreter` glob `/nix/store/*-glibc-*/...` matched two glibc versions in the rebuilt toktok-stack image, producing a malformed patchelf invocation. Take the interpreter from an existing system binary instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/203)
<!-- Reviewable:end -->
