### PR TITLE
fix: qtox toxcore version rc release being identified as older

### DIFF
--- a/tools/validate_pr.py
+++ b/tools/validate_pr.py
@@ -183,7 +183,9 @@ def check_toxcore_version(failures: list[str]) -> None:
         latest_toxcore_version = github.api("/repos/TokTok/c-toxcore/releases/latest")[
             "tag_name"
         ]
-        if f"v{toxcore_version}" == latest_toxcore_version:
+        if not git.parse_version(f"v{toxcore_version}") < git.parse_version(
+            latest_toxcore_version
+        ):
             check.ok(f"The toxcore version is up-to-date: {toxcore_version}")
         else:
             check.fail(


### PR DESCRIPTION
By actually comparing the version, we can see if the dockerfiles toxcore version might not already be newer than latest toxcore release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/ci-tools/206)
<!-- Reviewable:end -->
